### PR TITLE
regs: Fix MSIP width

### DIFF
--- a/data/clint.hjson.tpl
+++ b/data/clint.hjson.tpl
@@ -28,7 +28,8 @@
         swaccess: "rw",
         hwaccess: "hro",
         fields: [
-          { bits: "0", name: "P", desc: "Machine Software Interrupt Pending" }
+          { bits: "0", name: "P", desc: "Machine Software Interrupt Pending" },
+          { bits: "31:1", name: "RSVD", desc: "Reserved", resval: "0", swaccess: "ro", hwaccess: "none" }
         ]
       }
     },

--- a/data/clint.sv.tpl
+++ b/data/clint.sv.tpl
@@ -50,7 +50,7 @@ module clint import clint_reg_pkg::*; #(
     assign mtime_q = {reg2hw.mtime_high.q, reg2hw.mtime_low.q};
 % for i in range(cores):
     assign mtimecmp_q[${i}] = {reg2hw.mtimecmp_high${i}.q, reg2hw.mtimecmp_low${i}.q};
-    assign ipi_o[${i}] = reg2hw.msip[${i}].q;
+    assign ipi_o[${i}] = reg2hw.msip[${i}].p.q;
 % endfor
 
     assign {hw2reg.mtime_high.d, hw2reg.mtime_low.d} = mtime_q + 1;

--- a/src/clint.hjson
+++ b/src/clint.hjson
@@ -28,7 +28,8 @@
         swaccess: "rw",
         hwaccess: "hro",
         fields: [
-          { bits: "0", name: "P", desc: "Machine Software Interrupt Pending" }
+          { bits: "0", name: "P", desc: "Machine Software Interrupt Pending" },
+          { bits: "31:1", name: "RSVD", desc: "Reserved", resval: "0", swaccess: "ro", hwaccess: "none" }
         ]
       }
     },

--- a/src/clint.sv
+++ b/src/clint.sv
@@ -49,9 +49,9 @@ module clint import clint_reg_pkg::*; #(
 
     assign mtime_q = {reg2hw.mtime_high.q, reg2hw.mtime_low.q};
     assign mtimecmp_q[0] = {reg2hw.mtimecmp_high0.q, reg2hw.mtimecmp_low0.q};
-    assign ipi_o[0] = reg2hw.msip[0].q;
+    assign ipi_o[0] = reg2hw.msip[0].p.q;
     assign mtimecmp_q[1] = {reg2hw.mtimecmp_high1.q, reg2hw.mtimecmp_low1.q};
-    assign ipi_o[1] = reg2hw.msip[1].q;
+    assign ipi_o[1] = reg2hw.msip[1].p.q;
 
     assign {hw2reg.mtime_high.d, hw2reg.mtime_low.d} = mtime_q + 1;
     assign hw2reg.mtime_low.de = increase_timer;

--- a/src/clint_reg_pkg.sv
+++ b/src/clint_reg_pkg.sv
@@ -17,7 +17,9 @@ package clint_reg_pkg;
   ////////////////////////////
 
   typedef struct packed {
-    logic        q;
+    struct packed {
+      logic        q;
+    } p;
   } clint_reg2hw_msip_mreg_t;
 
   typedef struct packed {
@@ -72,7 +74,8 @@ package clint_reg_pkg;
   } clint_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] CLINT_MSIP_OFFSET = 16'h 0;
+  parameter logic [BlockAw-1:0] CLINT_MSIP_0_OFFSET = 16'h 0;
+  parameter logic [BlockAw-1:0] CLINT_MSIP_1_OFFSET = 16'h 4;
   parameter logic [BlockAw-1:0] CLINT_MTIMECMP_LOW0_OFFSET = 16'h 4000;
   parameter logic [BlockAw-1:0] CLINT_MTIMECMP_HIGH0_OFFSET = 16'h 4004;
   parameter logic [BlockAw-1:0] CLINT_MTIMECMP_LOW1_OFFSET = 16'h 4008;
@@ -82,7 +85,8 @@ package clint_reg_pkg;
 
   // Register index
   typedef enum int {
-    CLINT_MSIP,
+    CLINT_MSIP_0,
+    CLINT_MSIP_1,
     CLINT_MTIMECMP_LOW0,
     CLINT_MTIMECMP_HIGH0,
     CLINT_MTIMECMP_LOW1,
@@ -92,14 +96,15 @@ package clint_reg_pkg;
   } clint_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CLINT_PERMIT [7] = '{
-    4'b 0001, // index[0] CLINT_MSIP
-    4'b 1111, // index[1] CLINT_MTIMECMP_LOW0
-    4'b 1111, // index[2] CLINT_MTIMECMP_HIGH0
-    4'b 1111, // index[3] CLINT_MTIMECMP_LOW1
-    4'b 1111, // index[4] CLINT_MTIMECMP_HIGH1
-    4'b 1111, // index[5] CLINT_MTIME_LOW
-    4'b 1111  // index[6] CLINT_MTIME_HIGH
+  parameter logic [3:0] CLINT_PERMIT [8] = '{
+    4'b 1111, // index[0] CLINT_MSIP_0
+    4'b 1111, // index[1] CLINT_MSIP_1
+    4'b 1111, // index[2] CLINT_MTIMECMP_LOW0
+    4'b 1111, // index[3] CLINT_MTIMECMP_HIGH0
+    4'b 1111, // index[4] CLINT_MTIMECMP_LOW1
+    4'b 1111, // index[5] CLINT_MTIMECMP_HIGH1
+    4'b 1111, // index[6] CLINT_MTIME_LOW
+    4'b 1111  // index[7] CLINT_MTIME_HIGH
   };
 
 endpackage


### PR DESCRIPTION
According to the [aclic doc](https://github.com/riscv/riscv-aclint/blob/main/riscv-aclint.adoc#32-msip-registers-offsets-0x00000000---0x00003ff8), every hart's MSIP register is 32 bit wide with bits 1-31 hardwired to zero.