### PR TITLE
Bender.yml: Remove `description` field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Check generated sources
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.9
           cache: pip
@@ -32,7 +32,7 @@ jobs:
     name: Check Verilog sources
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Run Verible
       uses: chipsalliance/verible-linter-action@main
       with:
@@ -45,8 +45,8 @@ jobs:
     name: Check license
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Install Python requirements

--- a/Bender.yml
+++ b/Bender.yml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: SHL-0.51
 package:
   name: clint
-  description: RISC-V Core-local Interrupt Controller
   authors: [Florian Zaruba <zarubaf@iis.ee.ethz.ch>]
 
 dependencies:


### PR DESCRIPTION
`description` is not an official field in `Bender.yml` and will trigger a warning in newer bender versions:

```
warning: Ignoring unknown field `description` in manifest package for clint.
```